### PR TITLE
3.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='3.0.0',
+    version='3.0.1',
 
     description='SynapsePay Rest Native Python Library',
 

--- a/synapse_pay_rest/http_client.py
+++ b/synapse_pay_rest/http_client.py
@@ -61,7 +61,7 @@ class HttpClient():
         """Send a POST request to the API."""
         self.log_information(self.logging)
         headers = self.get_headers()
-        if 'idempotency_key' in kwargs:
+        if kwargs.get('idempotency_key'):
             headers['X-SP-IDEMPOTENCY-KEY'] = kwargs['idempotency_key']
         data = json.dumps(payload)
         response = self.session.post(self.base_url + url, data=data)

--- a/synapse_pay_rest/models/transactions/transaction.py
+++ b/synapse_pay_rest/models/transactions/transaction.py
@@ -170,7 +170,12 @@ class Transaction():
                                                       self.node.id,
                                                       self.id,
                                                       payload)
-        return self.from_response(self.node, response)
+        if 'trans' in response:
+            # API v3.1.0
+            return self.from_response(self.node, response['trans'])
+        else:
+            # API v3.1.1
+            return self.from_response(self.node, response)
 
     def cancel(self):
         """Cancel the transaction (will show in status).

--- a/synapse_pay_rest/tests/api/trans_tests.py
+++ b/synapse_pay_rest/tests/api/trans_tests.py
@@ -15,6 +15,8 @@ class TransTestCases(unittest.TestCase):
         response = self.client.nodes.create(self.user['_id'],
                                             ach_us_bank_login_payload)
         self.node = response['nodes'][0]
+        self.to_node = response['nodes'][1]
+        trans_create_payload['to']['id'] = self.to_node['_id']
 
     def test_create_a_new_transaction(self):
         trans = self.client.trans.create(self.user['_id'],

--- a/synapse_pay_rest/tests/fixtures/trans.py
+++ b/synapse_pay_rest/tests/fixtures/trans.py
@@ -1,9 +1,7 @@
-TO_NODE_ID = '57ec57be86c27345b3f8a159'
-
 trans_create_payload = {
     "to": {
         "type": "ACH-US",
-        "id": TO_NODE_ID
+        "id": ''
     },
     "amount": {
         "amount": 1.10,


### PR DESCRIPTION
- Add backwards compatibility for `Transaction.add_comment()` on API v3.1.0/3.1.1
- Remove hard-coded transaction ID from tests